### PR TITLE
Implementing core data nuke button

### DIFF
--- a/SwiftUI-UserLocation/SwiftUI-UserLocation.xcodeproj/project.pbxproj
+++ b/SwiftUI-UserLocation/SwiftUI-UserLocation.xcodeproj/project.pbxproj
@@ -478,7 +478,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -508,7 +508,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.5;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/SwiftUI-UserLocation/SwiftUI-UserLocation.xcodeproj/project.pbxproj
+++ b/SwiftUI-UserLocation/SwiftUI-UserLocation.xcodeproj/project.pbxproj
@@ -478,6 +478,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -507,6 +508,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/SwiftUI-UserLocation/SwiftUI-UserLocation.xcodeproj/project.pbxproj
+++ b/SwiftUI-UserLocation/SwiftUI-UserLocation.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		7C57E7FC299D7BE7002CAF8E /* config.json in Resources */ = {isa = PBXBuildFile; fileRef = 7C57E7FB299D7BE7002CAF8E /* config.json */; };
 		7C7589DF29871BC300A2443A /* InferenceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C7589DE29871BC300A2443A /* InferenceView.swift */; };
 		7C7589E1298736CE00A2443A /* dataset.txt in Resources */ = {isa = PBXBuildFile; fileRef = 7C7589E0298736CE00A2443A /* dataset.txt */; };
 		7CB2CC05297B83FE005C248E /* SwiftUI_UserLocationApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CB2CC04297B83FE005C248E /* SwiftUI_UserLocationApp.swift */; };
@@ -24,7 +25,6 @@
 		7CD934EC29861FB400E98C33 /* Location+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CD934E829861FB400E98C33 /* Location+CoreDataProperties.swift */; };
 		7CD934ED29861FB400E98C33 /* Name+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CD934E929861FB400E98C33 /* Name+CoreDataClass.swift */; };
 		7CD934EE29861FB400E98C33 /* Name+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CD934EA29861FB400E98C33 /* Name+CoreDataProperties.swift */; };
-		7CFDD925299444F80075838C /* config.json in Resources */ = {isa = PBXBuildFile; fileRef = 7CFDD924299444F80075838C /* config.json */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -45,6 +45,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		7C57E7FB299D7BE7002CAF8E /* config.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = config.json; path = ../../config.json; sourceTree = "<group>"; };
 		7C7589DE29871BC300A2443A /* InferenceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InferenceView.swift; sourceTree = "<group>"; };
 		7C7589E0298736CE00A2443A /* dataset.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = dataset.txt; sourceTree = "<group>"; };
 		7CB2CC01297B83FE005C248E /* SwiftUI-UserLocation.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "SwiftUI-UserLocation.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -66,7 +67,6 @@
 		7CD934E829861FB400E98C33 /* Location+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Location+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		7CD934E929861FB400E98C33 /* Name+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Name+CoreDataClass.swift"; sourceTree = "<group>"; };
 		7CD934EA29861FB400E98C33 /* Name+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Name+CoreDataProperties.swift"; sourceTree = "<group>"; };
-		7CFDD924299444F80075838C /* config.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = config.json; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -97,7 +97,7 @@
 		7CB2CBF8297B83FE005C248E = {
 			isa = PBXGroup;
 			children = (
-				7CFDD924299444F80075838C /* config.json */,
+				7C57E7FB299D7BE7002CAF8E /* config.json */,
 				7CB2CC03297B83FE005C248E /* SwiftUI-UserLocation */,
 				7CB2CC14297B8400005C248E /* SwiftUI-UserLocationTests */,
 				7CB2CC1E297B8401005C248E /* SwiftUI-UserLocationUITests */,
@@ -274,7 +274,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				7CB2CC0C297B8400005C248E /* Preview Assets.xcassets in Resources */,
-				7CFDD925299444F80075838C /* config.json in Resources */,
+				7C57E7FC299D7BE7002CAF8E /* config.json in Resources */,
 				7C7589E1298736CE00A2443A /* dataset.txt in Resources */,
 				7CB2CC09297B8400005C248E /* Assets.xcassets in Resources */,
 			);

--- a/SwiftUI-UserLocation/SwiftUI-UserLocation/DataView.swift
+++ b/SwiftUI-UserLocation/SwiftUI-UserLocation/DataView.swift
@@ -24,7 +24,8 @@ struct DataView: View {
     @State var fileURL=URL(string: "https://www.google.com")
     @State var openFile=false
     @State var dateFormatter = DateFormatter()
-    
+    @State private var showingAlert = false
+
     
     @Environment(\.managedObjectContext) private var viewContext
     
@@ -61,7 +62,17 @@ struct DataView: View {
 
                         Spacer()
                         Button("Nuke") {
-                            nukeData()
+                            showingAlert = true
+                        }
+                        .alert(isPresented: $showingAlert) {
+                            Alert(
+                                title: Text("Are you sure you want to clear all data?"),
+                                message: Text("There is no undo"),
+                                primaryButton: .destructive(Text("Delete")) {
+                                    nukeData()
+                                },
+                                secondaryButton: .cancel()
+                            )
                         }
 
                        Spacer()

--- a/SwiftUI-UserLocation/SwiftUI-UserLocation/DataView.swift
+++ b/SwiftUI-UserLocation/SwiftUI-UserLocation/DataView.swift
@@ -142,7 +142,7 @@ struct DataView: View {
     private func addLocation() {
             
             withAnimation {
-                let name_db = Name(context: viewContext)
+                
                 let location = Location(context: viewContext)
                 let addDateFormatter = DateFormatter()
                 addDateFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
@@ -175,6 +175,7 @@ struct DataView: View {
 //                    debugPrint(objectUpdate.value(forKey: "count"))
                 }
                 else{
+                    let name_db = Name(context: viewContext)
                     name_db.name=name
                     name_db.count = 1
                 }
@@ -301,10 +302,10 @@ struct DataView: View {
     func exportCSV() {
             let fileName = "export.csv"
             let path = NSURL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(fileName)
-            var csvText = "Timestamp,Longitude,Latitude,Altitude,Name\n"
+            var csvText = "Timestamp,Latitude,Longitude,Altitude,Name\n"
 
             for location in locations {
-                csvText += "\(location.time! ), \(location.longitude  ),\(location.latitude ),\(location.altitude ),\(location.name ?? "Not Found")\n"
+                csvText += "\(location.time! ),\(location.latitude  ),\(location.longitude ),\(location.altitude ),\(location.name ?? "Not Found")\n"
             }
 
             do {
@@ -340,8 +341,8 @@ struct DataView: View {
                         let name_db = Name(context: viewContext)
                         let castedDate = importDateFormatter.date(from: columns[0] )
                         location.time = castedDate ?? Date()
-                        location.longitude = Double(columns[1]) ?? 0.0
-                        location.latitude = Double(columns[2]) ?? 0.0
+                        location.latitude = Double(columns[1]) ?? 0.0
+                        location.longitude = Double(columns[2]) ?? 0.0
                         location.altitude = Double(columns[3]) ?? 0.0
                         location.name = columns[4]
 //                        location.count = 1


### PR DESCRIPTION
Added a button on the data tab that allows you to delete all of the core data entities. It then clears them from view. It has a popup alert that makes sure you really want to be clearing all of your data. Also side note, I had my min ios deployment to 15.2 because of my simulator, but I committed the file on accident so I went back in and changed it so it doesn't screw with the main file (ergo 15.5 adjustment commit).